### PR TITLE
Fix word-break

### DIFF
--- a/src/routes/(icon-title)/editor/+page.svelte
+++ b/src/routes/(icon-title)/editor/+page.svelte
@@ -441,7 +441,8 @@
 
 		span {
 			display: block;
-			width: fit-content;
+			width: max-content;
+			word-break: keep-all;
 		}
 	}
 


### PR DESCRIPTION
- 送り主の名前につく「より」が、エディタ画面で改行されていたのを修正